### PR TITLE
Revert "chore(deps): update helm release victoria-metrics-single to v0.11.0 (#315)"

### DIFF
--- a/umbrella-charts/vmsingle/Chart.yaml
+++ b/umbrella-charts/vmsingle/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 
 dependencies:
 - name: victoria-metrics-single
-  version: "0.11.0"
+  version: "0.10.1"
   repository: https://victoriametrics.github.io/helm-charts/
 - name: oauth2-proxy
   version: "7.7.14"


### PR DESCRIPTION
This reverts commit 12fcb013573153611d75b2338c19f4e3b0fa88c2.

See my comment in the upstream PR:
- https://github.com/VictoriaMetrics/helm-charts/pull/1297
- https://github.com/VictoriaMetrics/helm-charts/pull/1297#pullrequestreview-2276092046