### PR TITLE
feat(Cilium): Export more granular Hubble metrics

### DIFF
--- a/k3s-bootstrap/helm-values/cilium.yaml
+++ b/k3s-bootstrap/helm-values/cilium.yaml
@@ -45,7 +45,11 @@ hubble:
       - tcp
       - flow
       - icmp
-      - http
+      - http:labelsContext=source_namespace,destination_namespace,traffic_direction
+      - port-distribution
+        # 'httpV2' is an updated version of the existing 'http' metrics.
+        # These metrics can not be enabled at the same time as 'http'.
+      # - httpV2:exemplars=true;labelsContext=source_namespace,destination_namespace,traffic_direction
 
   relay:
     enabled: true


### PR DESCRIPTION
https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics

Details to consider:
> <img width="744" alt="image" src="https://github.com/user-attachments/assets/66d2cba4-f5fe-4fdc-b997-c9d23a01166f">

> 
> | Option Value                | Description                                                                                                                                                     |
> |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
> | `source_ip`                 | The source IP of the flow.                                                                                                                                      |
> | `source_namespace`          | The namespace of the pod if the flow source is from a Kubernetes pod.                                                                                           |
> | `source_pod`                | The pod name if the flow source is from a Kubernetes pod.                                                                                                       |
> | `source_workload`           | The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).                  |
> | `source_workload_kind`      | The kind of the source pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift).      |
> | `source_app`                | The app name of the source pod, derived from pod labels (`app.kubernetes.io/name`, `k8s-app`, or `app`).                                                        |
> | `destination_ip`            | The destination IP of the flow.                                                                                                                                 |
> | `destination_namespace`     | The namespace of the pod if the flow destination is from a Kubernetes pod.                                                                                      |
> | `destination_pod`           | The pod name if the flow destination is from a Kubernetes pod.                                                                                                  |
> | `destination_workload`      | The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).             |
> | `destination_workload_kind` | The kind of the destination pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift). |
> | `destination_app`           | The app name of the source pod, derived from pod labels (`app.kubernetes.io/name`, `k8s-app`, or `app`).                                                        |
> | `traffic_direction`         | Identifies the traffic direction of the flow. Possible values are `ingress`, `egress` and `unknown`.                                                            |