### PR TITLE
fix(Grafana): Downgrade to 11.6.0-ubuntu

### DIFF
--- a/umbrella-charts/grafana/values.yaml
+++ b/umbrella-charts/grafana/values.yaml
@@ -27,7 +27,7 @@ postgresql:
 
 grafana:
   image:
-    tag: "11.6.0+security-01-ubuntu"
+    tag: "11.6.0-ubuntu"
 
   podLabels:
     grafana-postgresql-client: "true"


### PR DESCRIPTION
Due to
- https://github.com/grafana/grafana/issues/104372

, I cannot upgrade to the latest version available. Let's use the previous version.