### PR TITLE
chore: Pull prometheus-alerts module via swisspost

### DIFF
--- a/grafana-config/argocd.tf
+++ b/grafana-config/argocd.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "argocd" {
 }
 
 module "argocd_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./argocd/alerts.yaml")
   folder_uid                  = grafana_folder.argocd.uid

--- a/grafana-config/cert-manager.tf
+++ b/grafana-config/cert-manager.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "cert_manager" {
 }
 
 module "cert_manager_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./cert-manager/alerts.yaml")
   folder_uid                  = grafana_folder.cert_manager.uid

--- a/grafana-config/cilium.tf
+++ b/grafana-config/cilium.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "cilium" {
 }
 
 module "cilium_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./cilium/alerts.yaml")
   folder_uid                  = grafana_folder.cilium.uid

--- a/grafana-config/coredns.tf
+++ b/grafana-config/coredns.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "coredns" {
 }
 
 module "coredns_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./coredns/alerts.yaml")
   folder_uid                  = grafana_folder.coredns.uid

--- a/grafana-config/ingress-nginx.tf
+++ b/grafana-config/ingress-nginx.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "ingress_nginx" {
 }
 
 module "ingress_nginx_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./ingress-nginx/alerts.yaml")
   folder_uid                  = grafana_folder.ingress_nginx.uid

--- a/grafana-config/keda.tf
+++ b/grafana-config/keda.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "keda" {
 }
 
 module "keda_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./keda/alerts.yaml")
   folder_uid                  = grafana_folder.keda.uid

--- a/grafana-config/kubernetes-mixin.tf
+++ b/grafana-config/kubernetes-mixin.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "kubernetes_mixin" {
 }
 
 module "kubernetes_mixin_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./kubernetes-mixin/alerts.yaml")
   folder_uid                  = grafana_folder.kubernetes_mixin.uid

--- a/grafana-config/kyverno.tf
+++ b/grafana-config/kyverno.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "kyverno" {
 }
 
 module "kyverno_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./kyverno/alerts.yaml")
   folder_uid                  = grafana_folder.kyverno.uid

--- a/grafana-config/node-exporter.tf
+++ b/grafana-config/node-exporter.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "node_exporter" {
 }
 
 module "node_exporter_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./node_exporter/alerts.yaml")
   folder_uid                  = grafana_folder.node_exporter.uid

--- a/grafana-config/victoria-metrics.tf
+++ b/grafana-config/victoria-metrics.tf
@@ -3,7 +3,8 @@ resource "grafana_folder" "victoria_metrics" {
 }
 
 module "victoria_metrics_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./victoria-metrics/alerts.yaml")
   folder_uid                  = grafana_folder.victoria_metrics.uid
@@ -13,7 +14,8 @@ module "victoria_metrics_alerts" {
 }
 
 module "victoria_metrics_single_alerts" {
-  source = "github.com/mkilchhofer/terraform-grafana-prometheus-alerts?ref=main"
+  source  = "swisspost/prometheus-alerts/grafana"
+  version = "~> 1.0"
 
   prometheus_alerts_file_path = file("./victoria-metrics/alerts-vmsingle.yaml")
   folder_uid                  = grafana_folder.victoria_metrics.uid


### PR DESCRIPTION
The module I introduced in my free time was moved to Swiss Post.

## Details

**Old location:**
github.com/mkilchhofer/terraform-grafana-prometheus-alerts

**New location:**
github.com/swisspost/terraform-grafana-prometheus-alerts

/cc: @the-technat